### PR TITLE
Fix and improve forced version check

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ flask>=0.11.1
 gpsoauth>=0.4.0
 werkzeug>=0.11.15
 sqlalchemy>=1.1.0
-aiopogo>=1.5.2
+aiopogo>=1.6.0
 polyline>=1.3.1
 aiohttp==1.3.*
 pogeo>=0.2


### PR DESCRIPTION
Do a simple and fast string comparison against the currently forced
version and then do a more thorough comparison with StrictVersion if
that failed.